### PR TITLE
Forcing struct alignment to resolve carried dependence issue when reading in data

### DIFF
--- a/2023_Spring/Lab1/PartB/complex.h
+++ b/2023_Spring/Lab1/PartB/complex.h
@@ -20,10 +20,10 @@ typedef ap_int<16> real_t;
 // Issue: https://piazza.com/class/lczabeu4s8s1io/post/22
 // Uses the C++ standard alignas type specifier to specify custom alignment of variables and user defined types.
 // Reference: https://docs.xilinx.com/r/en-US/ug1399-vitis-hls/Impact-of-Struct-Size-on-Pipelining
-struct alignas(8) complex_t {
+struct alignas(4) complex_t {
     real_t real;
     real_t imag;
-};
+}; // 16 * 2 = 32 bits = 4 bytes
 
 #define M 100
 #define N 150

--- a/2023_Spring/Lab1/PartB/complex.h
+++ b/2023_Spring/Lab1/PartB/complex.h
@@ -15,12 +15,15 @@
 
 #include <ap_int.h>
 
-typedef ap_int<16> int_t;
+typedef ap_int<16> real_t;
 
-typedef struct complex_t {
-    int_t real;
-    int_t imag;
-} complex_t;
+// Uses the C++ standard alignas type specifier to specify custom alignment of variables and user defined types.
+// Reference: https://docs.xilinx.com/r/en-US/ug1399-vitis-hls/Impact-of-Struct-Size-on-Pipelining
+
+struct alignas(8) complex_t {
+    real_t real;
+    real_t imag;
+};
 
 #define M 100
 #define N 150

--- a/2023_Spring/Lab1/PartB/complex.h
+++ b/2023_Spring/Lab1/PartB/complex.h
@@ -17,9 +17,9 @@
 
 typedef ap_int<16> real_t;
 
+// Issue: https://piazza.com/class/lczabeu4s8s1io/post/22
 // Uses the C++ standard alignas type specifier to specify custom alignment of variables and user defined types.
 // Reference: https://docs.xilinx.com/r/en-US/ug1399-vitis-hls/Impact-of-Struct-Size-on-Pipelining
-
 struct alignas(8) complex_t {
     real_t real;
     real_t imag;

--- a/2023_Spring/Lab1/PartB/main.cpp
+++ b/2023_Spring/Lab1/PartB/main.cpp
@@ -20,7 +20,7 @@ void loadMatrix(string filename, int numRows, int numCols)
     complex_t Mat_tb[numRows][numCols];
 
     int i = 0, j = 0, t = 0;
-    int_t real, imag;
+    real_t real, imag;
 
     std::ifstream Mat(filename);
 
@@ -51,7 +51,7 @@ void loadMatrix(string filename, int numRows, int numCols)
 
 int main()
 {
-    int_t real, imag; 
+    real_t real, imag; 
     int i, j, t;
     
     // Load input matrices and expected output matrix


### PR DESCRIPTION
Fixed issue stated in piazza post @22; change int_t to real_t int part B to agree with Part_A.