### PR TITLE
Updated Lab 1 Script to stop doing super-heavy optimizations automatically

### DIFF
--- a/2026_Spring/lab1/script.tcl
+++ b/2026_Spring/lab1/script.tcl
@@ -9,6 +9,8 @@ add_files top.cpp
 # add testbench
 add_files -tb host.cpp
 
+config_unroll -tripcount_threshold 0
+config_compile -pipeline_loops 0
 
 # FPGA part and clock configuration
 # default frequency is 100 MHz
@@ -25,7 +27,7 @@ cosim_design
 # Note: -flow syn performs RTL synthesis; 
 # -flow impl performs both RTL synthesis and implementation, including a detailed place and route of the RTL netlist.
 # implementation flow will take much longer time
-export_design -format ip_catalog
-#export_design -format ip_catalog -flow impl
+#export_design -format ip_catalog
+export_design -format ip_catalog -flow impl
 
 exit

--- a/2026_Spring/lab1/script.tcl
+++ b/2026_Spring/lab1/script.tcl
@@ -9,6 +9,7 @@ add_files top.cpp
 # add testbench
 add_files -tb host.cpp
 
+# stop automatic unrolling and pipelining by Vitis so baseline design fits on FPGA
 config_unroll -tripcount_threshold 0
 config_compile -pipeline_loops 0
 


### PR DESCRIPTION
Vitis 2025 automatically unrolls and pipelines large loops, which causes the baseline to be unimplementable. I added a couple of config lines to the tcl to stop it from doing that.