### PR TITLE
Change data_t fixed-point type precision to fit N_ROWS

### DIFF
--- a/2026_Spring/lab1/dcl.h
+++ b/2026_Spring/lab1/dcl.h
@@ -13,7 +13,7 @@
 // Fixed-point types
 // data_t: stored grid values
 // acc_t: wider accumulator for weighted sums
-typedef ap_fixed<24, 8, AP_RND, AP_SAT> data_t;
+typedef ap_fixed<24, 10, AP_RND, AP_SAT> data_t;
 
 //
 // Top-level kernel prototype


### PR DESCRIPTION
N_ROWS is 256 bits, but the ap_fixed only had 8 bits, so it would cap at 127.99.... This could potentially mess up some students' optimization.