### PR TITLE
Add configuration to prevent unrolling and pipelining for lab 3

### DIFF
--- a/2026_Spring/lab3/script.tcl
+++ b/2026_Spring/lab3/script.tcl
@@ -9,6 +9,9 @@ add_files top.cpp
 # add testbench
 add_files -tb host.cpp
 
+# stop automatic unrolling and pipelining by Vitis so baseline design fits on FPGA
+config_unroll -tripcount_threshold 0
+config_compile -pipeline_loops 0
 
 # FPGA part and clock configuration
 # default frequency is 100 MHz


### PR DESCRIPTION
Configured Vitis to stop automatic unrolling and pipelining.